### PR TITLE
Restrict portainer service to bind to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
   portainer:
     image: portainer/portainer
     ports:
-      - "9000:9000"
+      - "127.0.0.1:9000:9000"
     deploy:
       mode: replicated
       replicas: 1


### PR DESCRIPTION
By default, when providing the option `ports: ["dest-port:src-port"]` in a `docker-compose.yml` file, docker will bind the port to all interfaces of the host machine. It means that everyone in the same network as the host machine can access the portainer web ui, and if the account is not set up yet, an attacker can use freely the docker socket of the host.

## Scenario example

The attacker run an `nmap` and see that the port 9000 is open on the victim machine. He goes on the web UI and creates his account. We can now run a container and do crypto-money mining, or steal files from the victim machine by mounting a volume in its own container or send a virus on the host machine.

## Recommandations

Restrict interfaces on which the portainer port is bind. This PR makes the portainer service bind the port to localhost only.  The user can still go on the web ui with http://localhost:9000 but people in his network can't.